### PR TITLE
Dep injection

### DIFF
--- a/data/access.go
+++ b/data/access.go
@@ -37,26 +37,26 @@ func (todoItems *DBTodoItems) scan(rows *sql.Rows) error {
 
 // TodoDB provides methods for accessing DB data
 type TodoDB struct {
-	db *sql.DB
+	DB *sql.DB
 }
 
 // OpenDb opens a MySQL database with the specified dbname and dbuser
 func (todoDb *TodoDB) OpenDb(dbname string, dbuser string) error {
 	db, err := sql.Open("mysql", dbuser+":pass@/"+dbname)
-	todoDb.db = db
+	todoDb.DB = db
 	return err
 }
 
 // CreateTablesIfNotExists creates any MySQL tables that do not exist
 func (todoDb *TodoDB) CreateTablesIfNotExists() error {
-	_, err := todoDb.db.Exec(sqlCreateTodoItemsTable)
+	_, err := todoDb.DB.Exec(sqlCreateTodoItemsTable)
 	return err
 }
 
 // SelectAllTodoItems returns all rows from the DB as DBTodoItems
 func (todoDb *TodoDB) SelectAllTodoItems() (items *DBTodoItems, err error) {
 	todoItems := &DBTodoItems{}
-	rows, err := todoDb.db.Query(sqlSelectAllTodoItems)
+	rows, err := todoDb.DB.Query(sqlSelectAllTodoItems)
 	if err != nil {
 		return nil, err
 	}
@@ -65,7 +65,7 @@ func (todoDb *TodoDB) SelectAllTodoItems() (items *DBTodoItems, err error) {
 }
 
 func (todoDb *TodoDB) SelectSingleTodoItem(item *DBTodoItem) (todoItem *DBTodoItem, err error) {
-	row := todoDb.db.QueryRow(
+	row := todoDb.DB.QueryRow(
 		sqlSelectSingleTodoItem,
 		item.Id)
 	if err != nil {
@@ -83,7 +83,7 @@ func (todoDb *TodoDB) SelectSingleTodoItem(item *DBTodoItem) (todoItem *DBTodoIt
 
 // InsertTodoItem inserts a single DBTodoItem into the DB
 func (todoDb *TodoDB) InsertTodoItem(item *DBTodoItem) error {
-	_, err := todoDb.db.Exec(
+	_, err := todoDb.DB.Exec(
 		sqlInsertTodoItem,
 		item.Title)
 	return err
@@ -91,7 +91,7 @@ func (todoDb *TodoDB) InsertTodoItem(item *DBTodoItem) error {
 
 // UpdateTodoItem updates a single DBTodoItem within the DB
 func (todoDb *TodoDB) UpdateTodoItem(item *DBTodoItem) error {
-	_, err := todoDb.db.Exec(
+	_, err := todoDb.DB.Exec(
 		sqlUpdateTodoItem,
 		item.Title,
 		item.Id)
@@ -100,7 +100,7 @@ func (todoDb *TodoDB) UpdateTodoItem(item *DBTodoItem) error {
 
 // UpdateTodoItem updates a single DBTodoItem within the DB
 func (todoDb *TodoDB) DeleteTodoItem(item *DBTodoItem) error {
-	_, err := todoDb.db.Exec(
+	_, err := todoDb.DB.Exec(
 		sqlDeleteTodoItem,
 		item.Id)
 	return err

--- a/models/todoitem.go
+++ b/models/todoitem.go
@@ -1,6 +1,12 @@
 package models
 
+import "database/sql"
+
 type TodoItem struct {
 	Id    int    `json:"id"`
 	Title string `json:"title"`
+}
+
+type TodoItemModel struct {
+	DB *sql.DB
 }

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -12,64 +12,59 @@ import (
 	"github.com/gorilla/mux"
 )
 
-func createTodoItem(w http.ResponseWriter, r *http.Request) {
-	log.Println("endpoint: create todoItem")
+func (env *env) createTodoItem(w http.ResponseWriter, r *http.Request) {
 	reqBody, _ := ioutil.ReadAll(r.Body)
 	var item data.DBTodoItem
 	json.Unmarshal(reqBody, &item)
-	err := db.InsertTodoItem(&item)
+	err := env.todoDB.InsertTodoItem(&item)
 	if err != nil {
 		log.Printf("FAIL: create todoItem: %v\n", err)
 	}
 }
 
-func returnAllTodoItems(w http.ResponseWriter, r *http.Request) {
-	log.Println("endpoint: todoItems")
-	items, err := db.SelectAllTodoItems()
+func (env *env) returnAllTodoItems(w http.ResponseWriter, r *http.Request) {
+	items, err := env.todoDB.SelectAllTodoItems()
 	if err != nil {
 		log.Printf("FAIL: return all todoItems: %v\n", err)
 	}
 	json.NewEncoder(w).Encode(items)
 }
 
-func returnSingleTodoItem(w http.ResponseWriter, r *http.Request) {
-	log.Println("endpoint: single todoItem")
+func (env *env) returnSingleTodoItem(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	key, _ := strconv.Atoi(vars["id"])
 	item := data.DBTodoItem{&models.TodoItem{
 		Id:    key,
 		Title: "",
 	}}
-	todoItem, err := db.SelectSingleTodoItem(&item)
+	todoItem, err := env.todoDB.SelectSingleTodoItem(&item)
 	if err != nil {
 		log.Printf("FAIL: return single todoItem: %v\n", err)
 	}
 	json.NewEncoder(w).Encode(todoItem)
 }
 
-func updateTodoItem(w http.ResponseWriter, r *http.Request) {
-	log.Println("endpoint: update todoItem")
+func (env *env) updateTodoItem(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	key, _ := strconv.Atoi(vars["id"])
 	reqBody, _ := ioutil.ReadAll(r.Body)
 	var item data.DBTodoItem
 	json.Unmarshal(reqBody, &item)
 	item.Id = key
-	err := db.UpdateTodoItem(&item)
+	err := env.todoDB.UpdateTodoItem(&item)
 	if err != nil {
 		log.Printf("FAIL: update todoItem: %v\n", err)
 	}
 }
 
-func deleteTodoItem(w http.ResponseWriter, r *http.Request) {
-	log.Println("endpoint: delete todoItem")
+func (env *env) deleteTodoItem(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	key, _ := strconv.Atoi(vars["id"])
 	item := data.DBTodoItem{&models.TodoItem{
 		Id:    key,
 		Title: "",
 	}}
-	err := db.DeleteTodoItem(&item)
+	err := env.todoDB.DeleteTodoItem(&item)
 	if err != nil {
 		log.Printf("FAIL: delete todoItem: %v\n", err)
 	}

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -12,8 +12,6 @@ import (
 	"github.com/gorilla/mux"
 )
 
-var db *data.TodoDB
-
 func createTodoItem(w http.ResponseWriter, r *http.Request) {
 	log.Println("endpoint: create todoItem")
 	reqBody, _ := ioutil.ReadAll(r.Body)
@@ -75,17 +73,4 @@ func deleteTodoItem(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		log.Printf("FAIL: delete todoItem: %v\n", err)
 	}
-}
-
-func handleRequests(dbp *data.TodoDB) {
-	db = dbp
-	myRouter := mux.NewRouter().StrictSlash(true)
-	// Static
-	myRouter.HandleFunc("/tasks", returnAllTodoItems)
-	myRouter.HandleFunc("/task", createTodoItem).Methods("POST")
-	// Parameterized
-	myRouter.HandleFunc("/task/{id}", updateTodoItem).Methods("PUT")
-	myRouter.HandleFunc("/task/{id}", deleteTodoItem).Methods("DELETE")
-	myRouter.HandleFunc("/task/{id}", returnSingleTodoItem)
-	log.Fatal(http.ListenAndServe(":10000", myRouter))
 }

--- a/server/main.go
+++ b/server/main.go
@@ -13,21 +13,33 @@ const (
 	dbuser = "root"
 )
 
+type env struct {
+	todoDB data.TodoDB
+}
+
 func main() {
 	log.Println("Initializing Database")
 	db := &data.TodoDB{}
-	db.OpenDb(dbname, dbuser)
-	err := db.CreateTablesIfNotExists()
+	err := db.OpenDb(dbname, dbuser)
+	if err != nil {
+		log.Fatalf("unable to open database %v", err)
+	}
+	err = db.CreateTablesIfNotExists()
 	if err != nil {
 		log.Fatalf("table not created %v", err)
 	}
-
+	env := &env{
+		todoDB: *db,
+	}
 	myRouter := mux.NewRouter().StrictSlash(true)
-	myRouter.HandleFunc("/tasks", returnAllTodoItems)
-	myRouter.HandleFunc("/task", createTodoItem).Methods("POST")
-	myRouter.HandleFunc("/task/{id}", updateTodoItem).Methods("PUT")
-	myRouter.HandleFunc("/task/{id}", deleteTodoItem).Methods("DELETE")
-	myRouter.HandleFunc("/task/{id}", returnSingleTodoItem)
+	// Middleware
+	myRouter.Use(logging)
+	// Routes
+	myRouter.HandleFunc("/tasks", env.returnAllTodoItems)
+	myRouter.HandleFunc("/task", env.createTodoItem).Methods("POST")
+	myRouter.HandleFunc("/task/{id}", env.updateTodoItem).Methods("PUT")
+	myRouter.HandleFunc("/task/{id}", env.deleteTodoItem).Methods("DELETE")
+	myRouter.HandleFunc("/task/{id}", env.returnSingleTodoItem)
 
 	log.Println("Listening for requests")
 	log.Fatal(http.ListenAndServe(":10000", myRouter))

--- a/server/main.go
+++ b/server/main.go
@@ -2,8 +2,10 @@ package main
 
 import (
 	"log"
+	"net/http"
 
 	"github.com/CJHouser/tasklist/data"
+	"github.com/gorilla/mux"
 )
 
 const (
@@ -19,6 +21,14 @@ func main() {
 	if err != nil {
 		log.Fatalf("table not created %v", err)
 	}
+
+	myRouter := mux.NewRouter().StrictSlash(true)
+	myRouter.HandleFunc("/tasks", returnAllTodoItems)
+	myRouter.HandleFunc("/task", createTodoItem).Methods("POST")
+	myRouter.HandleFunc("/task/{id}", updateTodoItem).Methods("PUT")
+	myRouter.HandleFunc("/task/{id}", deleteTodoItem).Methods("DELETE")
+	myRouter.HandleFunc("/task/{id}", returnSingleTodoItem)
+
 	log.Println("Listening for requests")
-	handleRequests(db)
+	log.Fatal(http.ListenAndServe(":10000", myRouter))
 }


### PR DESCRIPTION
The goal of this PR was to remove the global database object being used by the database access layer. Dependency injection solves this problem, although it feels a bit messy right now. I also came across the concept of middleware while looking for resources on the context package (was going to use context as solution for database object until I came across dependency injection.) I added a simple logging middleware that let me take out all my "endpoint hit" logging statements that were repeated in each handler!